### PR TITLE
Feature/encryption at rest

### DIFF
--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -2565,7 +2565,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-iOS/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FMDB-iOS/FMDB.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac-iOS/GoogleToolboxForMac.framework",
@@ -2584,7 +2584,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		46CB91A9A17B58E6709D1B46 /* [CP] Embed Pods Frameworks */ = {
@@ -2593,7 +2593,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-iOS/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FMDB-iOS/FMDB.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac-iOS/GoogleToolboxForMac.framework",
@@ -2618,7 +2618,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		754C5939D1D74685677B9518 /* [CP] Check Pods Manifest.lock */ = {
@@ -2645,7 +2645,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-macOS/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FMDB-macOS/FMDB.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac-macOS/GoogleToolboxForMac.framework",
@@ -2670,7 +2670,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		8FC98010A5F17C9CB6C14A62 /* [CP] Check Pods Manifest.lock */ = {
@@ -2743,7 +2743,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-macOS/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FMDB-macOS/FMDB.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac-macOS/GoogleToolboxForMac.framework",
@@ -2762,7 +2762,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		DE64C5C18FA0A3DCA885795D /* [CP] Check Pods Manifest.lock */ = {

--- a/CDTDatastore.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CDTDatastore.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:CDTDatastore.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/CDTDatastore.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CDTDatastore.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/CDTDatastore/CDTDatastore.h
+++ b/CDTDatastore/CDTDatastore.h
@@ -57,11 +57,20 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  * @see CDTDocumentRevision
  *
  */
+
+@protocol DatastoreDelegate <NSObject>
+@optional
+- (void)didRecieveResponseWith:(NSError*_Nullable)error datastore: (CDTDatastore*_Nullable)store;
+@end
+
 @interface CDTDatastore : NSObject
 
 @property (nonnull, nonatomic, strong, readonly) TD_Database *database;
 
 + (nonnull NSString *)versionString;
+
+@property (nonnull, strong) NSString *directory;
+@property (nonatomic, weak) id <DatastoreDelegate> _Nullable _Nullable delegate;
 
 /**
  *
@@ -71,8 +80,8 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  * @param database the database where this datastore should save documents.
  *
  */
-- (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager database:(nonnull TD_Database *)database;
-
+//- (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager database:(nonnull TD_Database *)database;
+- (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager database:(nonnull TD_Database *)database directory: (nonnull NSString *)directory;
 /**
  * The number of document in the datastore.
  */
@@ -240,4 +249,21 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  * @param error will point to an NSError object in the case of an error
  */
 - (BOOL)compactWithError:(NSError *__autoreleasing __nullable * __nullable)error;
+
+/**
+ *
+ * This function will be used to set default encryption policy before starting any operation and after finishing an operation on DB. Eg. - Default policy we've set is before starting an operation on DB NSFileProtectionCompleteUnlessOpen before starting any operation on DB and we set NSFileProtectionComplete after finishing the operation on DB.
+ * @param before Policy that should be set BEFORE starting an operation on DB
+ * @param after Policy that should be set AFTER finishing an operation on DB
+ *
+ */
+//-(void)setEncryptionBeforeStartingProcess: (NSFileProtectionType _Nonnull )before afterFinishProcess: (NSFileProtectionType _Nullable )after;
+
+-(void)encryptFile: (NSFileProtectionType _Nonnull)type;
+
+- (NSFileProtectionType _Nullable)appliedProtectionPolicyOnDb;
+
+-(void)addNewTask;
+
+-(void)removeOneTask;
 @end

--- a/CDTDatastore/CDTDatastore.h
+++ b/CDTDatastore/CDTDatastore.h
@@ -70,7 +70,32 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
 + (nonnull NSString *)versionString;
 
 @property (nonnull, strong) NSString *directory;
-@property (nonatomic, weak) id <DatastoreDelegate> _Nullable _Nullable delegate;
+@property (nonatomic, weak) id <DatastoreDelegate> _Nullable delegate;
+
+
+
+
+/**
+ * Encryption Modes allowed at present.
+ *
+ * @param mode1  Apps are guaranteed to complete syncing within 10 seconds, it will set NSFileProtectionType to CompleteUnlessOpen till 10 seconds finishes. After 10 seconds it will be change to NSFileProtectionType to Complete automatically and any running syncing won't be able to access Files if application is in background.
+ *
+ * @param mode2  Apps cannot complete syncing within 10 seconds and need more time, Mode2 will give 20 seconds timeframe to finish any running syncing. After 20 seconds it will be change to NSFileProtectionType to Complete automatically and any running syncing won't be able to access Files if application is in background.
+ *
+ * @param Background Apps need to periodically run in the background to do things such as automatic syncs. It will give 30 seconds timeframe to finish any operation  in the background. After 30 seconds it will be change to NSFileProtectionType to Complete automatically and any running operation won't be able to access Files because application is in background.
+ *
+*/
+//enum EncryptionModes {
+//    mode1,
+//    mode2,
+//    background
+//};
+
+typedef NS_ENUM(NSUInteger, EncryptionModes) {
+    mode1 = 1,
+    mode2 = 2,
+    background = 3
+};
 
 /**
  *
@@ -250,20 +275,22 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  */
 - (BOOL)compactWithError:(NSError *__autoreleasing __nullable * __nullable)error;
 
-/**
- *
- * This function will be used to set default encryption policy before starting any operation and after finishing an operation on DB. Eg. - Default policy we've set is before starting an operation on DB NSFileProtectionCompleteUnlessOpen before starting any operation on DB and we set NSFileProtectionComplete after finishing the operation on DB.
- * @param before Policy that should be set BEFORE starting an operation on DB
- * @param after Policy that should be set AFTER finishing an operation on DB
- *
- */
-//-(void)setEncryptionBeforeStartingProcess: (NSFileProtectionType _Nonnull )before afterFinishProcess: (NSFileProtectionType _Nullable )after;
-
+/// This function will help to set FILE Protection manually by users.
+/// @param type Its FileProtection Type Enum provided by Apple, user can pass any Protection case whatever they need to set on there files.
 -(void)encryptFile: (NSFileProtectionType _Nonnull)type;
 
+///  This function will help to set Encryption MODE. Set a mode according to your need.
+/// @param mode - It's a ENUM value that users can set from predefined enum cases.
+-(void)setEncryptionMode: (EncryptionModes)mode;
+
+/// This funtion will return the current applied file protection policy on files.
 - (NSFileProtectionType _Nullable)appliedProtectionPolicyOnDb;
 
+/// These below two functionsare being used internally only to manage tasks pool.
+/// This function will increase the runningProcess variable count by 1. runningProcess is an internal Integer variable declared in CDTDatastore.m class, we're using it to check if we've any running process at the time when we're moving app to background. If we have any ongoing process that could
+/*
 -(void)addNewTask;
 
 -(void)removeOneTask;
+ */
 @end

--- a/CDTDatastore/CDTDatastore.h
+++ b/CDTDatastore/CDTDatastore.h
@@ -85,13 +85,8 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  * @param Background Apps need to periodically run in the background to do things such as automatic syncs. It will give 30 seconds timeframe to finish any operation  in the background. After 30 seconds it will be change to NSFileProtectionType to Complete automatically and any running operation won't be able to access Files because application is in background.
  *
 */
-//enum EncryptionModes {
-//    mode1,
-//    mode2,
-//    background
-//};
 
-typedef NS_ENUM(NSUInteger, EncryptionModes) {
+typedef NS_ENUM(NSUInteger, OTFProtectionLevel) {
     mode1 = 1,
     mode2 = 2,
     background = 3
@@ -279,9 +274,9 @@ typedef NS_ENUM(NSUInteger, EncryptionModes) {
 /// @param type Its FileProtection Type Enum provided by Apple, user can pass any Protection case whatever they need to set on there files.
 -(void)encryptFile: (NSFileProtectionType _Nonnull)type;
 
-///  This function will help to set Encryption MODE. Set a mode according to your need.
+///  This function will help to set Protection level. Set a mode according to your need.
 /// @param mode - It's a ENUM value that users can set from predefined enum cases.
--(void)setEncryptionMode: (EncryptionModes)mode;
+-(void)setProtectionLevel: (OTFProtectionLevel)level;
 
 /// This funtion will return the current applied file protection policy on files.
 - (NSFileProtectionType _Nullable)appliedProtectionPolicyOnDb;

--- a/CDTDatastore/CDTDatastore.m
+++ b/CDTDatastore/CDTDatastore.m
@@ -250,8 +250,8 @@ int runningProcess;
 
 ///  This function will help to set Encryption MODE. Set a mode according to your need.
 /// @param mode - It's a ENUM value that users can set from predefined enum cases.
--(void)setEncryptionMode: (EncryptionModes)mode {
-    switch(mode) {
+-(void)setProtectionLevel: (OTFProtectionLevel)level {
+    switch(level) {
         case mode1:
             [self setMode1];
             break;

--- a/CDTDatastore/CDTDatastoreManager.m
+++ b/CDTDatastore/CDTDatastoreManager.m
@@ -71,8 +71,7 @@ NSString *const CDTExtensionsDirName = @"_extensions";
         NSString *errorReason = nil;
         TD_Database *db = [self.manager databaseNamed:name];
         if (db) {
-            datastore = [[CDTDatastore alloc] initWithManager:self database:db encryptionKeyProvider:provider];
-            
+            datastore = [[CDTDatastore alloc] initWithManager:self database:db encryptionKeyProvider:provider directory: [self.manager directory]];
             if (!datastore) {
                 errorReason = NSLocalizedString(@"Wrong key?", nil);
             }
@@ -140,7 +139,7 @@ NSString *const CDTExtensionsDirName = @"_extensions";
             // called on it _before_ we attempt to delete its underlying database
             CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"calling close from delete %@", name);
             [_openDatastores removeObjectForKey:name];
-            NSString *dbPath = [self.manager pathForName:name];;
+            NSString *dbPath = [self.manager pathForName:name];
             NSString *extPath = [dbPath stringByDeletingLastPathComponent];
             extPath = [extPath
                        stringByAppendingPathComponent:[name stringByAppendingString:CDTExtensionsDirName]];

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
@@ -166,10 +166,17 @@
                 completionHandler:(void (^ __nonnull)(NSError *__nullable))completionHandler
 {
     NSError* error = nil;
-    CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:completionHandler];
+    CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:^(NSError * err) {
+        [self encryptFile:NSFileProtectionCompleteUnlessOpen];
+        [self removeOneTask];
+        [self.delegate didRecieveResponseWith:err datastore:self];
+    }];
+
     CDTReplicator* replicator = [self pullReplicationSource:source
                                                       username:username password:password withDelegate:delegate error:&error];
-    if (!error){
+    if (!error) {
+        [self encryptFile:NSFileProtectionComplete];
+        [self addNewTask];
         [replicator startWithError:&error];
     }
 

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
@@ -167,16 +167,14 @@
 {
     NSError* error = nil;
     CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:^(NSError * err) {
-        [self encryptFile:NSFileProtectionCompleteUnlessOpen];
-        [self removeOneTask];
+ //       [self removeOneTask];
         [self.delegate didRecieveResponseWith:err datastore:self];
     }];
 
     CDTReplicator* replicator = [self pullReplicationSource:source
                                                       username:username password:password withDelegate:delegate error:&error];
-    if (!error) {
-        [self encryptFile:NSFileProtectionComplete];
-        [self addNewTask];
+    if (!error) { 
+//        [self addNewTask];
         [replicator startWithError:&error];
     }
 

--- a/CDTDatastore/Encryption/CDTDatastore+EncryptionKey.h
+++ b/CDTDatastore/Encryption/CDTDatastore+EncryptionKey.h
@@ -31,9 +31,14 @@
  */
 - (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager
                        database:(nonnull TD_Database *)database
-          encryptionKeyProvider:(nullable id<CDTEncryptionKeyProvider>)provider;
+          encryptionKeyProvider:(nonnull id<CDTEncryptionKeyProvider>)provider
+                               directory: (nonnull NSString *)directory;
 
-/**
+/*- (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager
+                       database:(nonnull TD_Database *)database
+          encryptionKeyProvider:(nullable id<CDTEncryptionKeyProvider>)provider;
+*/
+/*
  * Return the key provider used to encrypt the datastore
  */
 - (nullable id<CDTEncryptionKeyProvider>)encryptionKeyProvider;

--- a/CDTDatastore/touchdb/TD_DatabaseManager.m
+++ b/CDTDatastore/touchdb/TD_DatabaseManager.m
@@ -75,11 +75,17 @@ static NSCharacterSet* kIllegalNameChars;
         _databases = [[NSMutableDictionary alloc] init];
         _options = options ? *options : kTD_DatabaseManagerDefaultOptions;
 
+        NSDictionary *attributes = nil;
+        #if TARGET_OS_IPHONE
+        if (@available(iOS 9.0, *)) {
+            attributes = @{NSFileProtectionKey : NSFileProtectionCompleteUnlessOpen};
+        }
+       #endif
         // Create the directory but don't fail if it already exists:
         NSError* error;
         if (![[NSFileManager defaultManager] createDirectoryAtPath:_dir
                                        withIntermediateDirectories:NO
-                                                        attributes:nil
+                                                        attributes:attributes
                                                              error:&error]) {
             BOOL isDir;
             if (!TDIsFileExistsError(error) ||

--- a/PodFile
+++ b/PodFile
@@ -26,7 +26,7 @@ abstract_target 'base' do
         pod 'Specta'
         pod 'Expecta'
         pod 'OCMock'
-        pod 'OHHTTPStubs'
+        pod 'OHHTTPStubs', '~> 8.0.0'
         pod 'RSSwizzle'
         pod MRDatabaseContentChecker, :git => 'https://github.com/rhyshort/MRDatabaseContentChecker.git'
 

--- a/Project/Project.xcodeproj/project.pbxproj
+++ b/Project/Project.xcodeproj/project.pbxproj
@@ -238,7 +238,6 @@
 				ORGANIZATIONNAME = Cloudant;
 				TargetAttributes = {
 					27C1CDC2184E2D9C000604EF = {
-						DevelopmentTeam = BS4R9ZW87K;
 						ProvisioningStyle = Automatic;
 					};
 					27C1CDE3184E2D9C000604EF = {
@@ -478,12 +477,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = BS4R9ZW87K;
+				DEVELOPMENT_TEAM = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Project/Project-Prefix.pch";
 				INFOPLIST_FILE = "Project/Project-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_BUNDLE_IDENTIFIER = imran.personal.team;
+				PRODUCT_BUNDLE_IDENTIFIER = "-com.cloudant.--PRODUCT-NAME-rfc1034identifier--";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
@@ -497,12 +496,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = BS4R9ZW87K;
+				DEVELOPMENT_TEAM = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Project/Project-Prefix.pch";
 				INFOPLIST_FILE = "Project/Project-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_BUNDLE_IDENTIFIER = imran.personal.team;
+				PRODUCT_BUNDLE_IDENTIFIER = "-com.cloudant.--PRODUCT-NAME-rfc1034identifier--";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;

--- a/Project/Project.xcodeproj/project.pbxproj
+++ b/Project/Project.xcodeproj/project.pbxproj
@@ -482,7 +482,7 @@
 				GCC_PREFIX_HEADER = "Project/Project-Prefix.pch";
 				INFOPLIST_FILE = "Project/Project-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "-com.cloudant.--PRODUCT-NAME-rfc1034identifier--";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudant.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
@@ -501,7 +501,7 @@
 				GCC_PREFIX_HEADER = "Project/Project-Prefix.pch";
 				INFOPLIST_FILE = "Project/Project-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "-com.cloudant.--PRODUCT-NAME-rfc1034identifier--";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudant.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;

--- a/Project/Project.xcodeproj/project.pbxproj
+++ b/Project/Project.xcodeproj/project.pbxproj
@@ -199,7 +199,6 @@
 				27C1CDC0184E2D9C000604EF /* Frameworks */,
 				27C1CDC1184E2D9C000604EF /* Resources */,
 				0ACCC6334D2AE204A575DDD7 /* [CP] Embed Pods Frameworks */,
-				FAFE0C0908533A384F9323D2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -238,6 +237,10 @@
 				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = Cloudant;
 				TargetAttributes = {
+					27C1CDC2184E2D9C000604EF = {
+						DevelopmentTeam = BS4R9ZW87K;
+						ProvisioningStyle = Automatic;
+					};
 					27C1CDE3184E2D9C000604EF = {
 						TestTargetID = 27C1CDC2184E2D9C000604EF;
 					};
@@ -248,6 +251,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -291,7 +295,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Project/Pods-Project-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Project/Pods-Project-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CDTDatastore/CDTDatastore.framework",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FMDB/FMDB.framework",
@@ -306,7 +310,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Project/Pods-Project-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Project/Pods-Project-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F89A156CF8A2F5DE5C622ED1 /* [CP] Check Pods Manifest.lock */ = {
@@ -325,21 +329,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		FAFE0C0908533A384F9323D2 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Project/Pods-Project-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -487,12 +476,16 @@
 			baseConfigurationReference = 6CF7CD6E9CDD31FC50E9722B /* Pods-Project.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = BS4R9ZW87K;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Project/Project-Prefix.pch";
 				INFOPLIST_FILE = "Project/Project-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudant.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = imran.personal.team;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -502,12 +495,16 @@
 			baseConfigurationReference = 621CD83AE51E6D0F61B20539 /* Pods-Project.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = BS4R9ZW87K;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Project/Project-Prefix.pch";
 				INFOPLIST_FILE = "Project/Project-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudant.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = imran.personal.team;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Project/Project.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Project/Project.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Project/Project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Project/Project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Project/Project/CDTAppDelegate.m
+++ b/Project/Project/CDTAppDelegate.m
@@ -135,7 +135,6 @@
     }
 
     CDTDatastore *datastore = [self.manager datastoreNamed:@"todo_items" error:&outError];
-    [datastore setEncryptionBeforeStartingProcess:NSFileProtectionNone afterFinishProcess:NSFileProtectionCompleteUnlessOpen];
     if (nil != outError) {
         NSLog(@"Error creating datastore: %@", outError);
         exit(1);

--- a/Project/Project/CDTAppDelegate.m
+++ b/Project/Project/CDTAppDelegate.m
@@ -135,7 +135,7 @@
     }
 
     CDTDatastore *datastore = [self.manager datastoreNamed:@"todo_items" error:&outError];
-
+    [datastore setEncryptionBeforeStartingProcess:NSFileProtectionNone afterFinishProcess:NSFileProtectionCompleteUnlessOpen];
     if (nil != outError) {
         NSLog(@"Error creating datastore: %@", outError);
         exit(1);

--- a/Project/Project/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Project/Project/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,22 +2,52 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/README.md
+++ b/README.md
@@ -286,6 +286,52 @@ has more features than the previous implementation.  For details about
 migrating to a 0.16.0+ indexing and query version from a previous version
 see [Index and Querying Migration](https://github.com/cloudant/CDTDatastore/blob/master/doc/query-migration.md).
 
+
+### File Encryption Modes
+
+You can set a MODE from available options. Setting any mode will ensure the file protection that you want to apply on your files before starting and after finishing any operation on the files.
+There are 4 types of File protections available in iOS categorised by the key "NSFileProtectionType", and below are the different types of file protection -
+
+### **NSFileProtectionComplete** -  The file is stored in an encrypted format on disk and cannot be read from or written to while the device is locked or booting.
+
+### **NSFileProtectionCompleteUnlessOpen** - The file is stored in an encrypted format on disk after it is closed.
+
+### **NSFileProtectionCompleteUntilFirstUserAuthentication** - The file is an encrypted format on disk and cannot be accessed until after the device has booted.
+
+### **NSFIleProtectionNone** - The file has no special protections associated with it.
+
+By Default value for **NSFileProtectionType** is **NSFileProtectionCompleteUntilFirstUserAuthentication**, that user can change at any point of time.
+
+
+In CDTDatastore framework, we have given 3 types of MODES that will help to set encryptions with some different behaviours. Below are the available modes -
+
+### **mode1** - User can use this mode in case Apps are guaranteed to complete syncing within 10 seconds, it will set NSFileProtectionType to CompleteUnlessOpen till 10 seconds finishes. After 10 seconds it will be change the NSFileProtectionType to Complete automatically and any running sycing  won't be able to access Files in background.
+
+### **mode2** - User can use this mode in case Apps cannot finish syncing within 10 seconds and need more time. Mode2 will give 20 seconds timeframe to finish any running syncing. After 20 seconds it will be change to NSFileProtectionType to Complete automatically and any running syncing won't be able to access Files in background.
+
+### **background** User can use this mode in case Apps need to periodically run in the background to do things such as automatic syncs. It will give 30 seconds timeframe to finish any operation in background. After 30 seconds it will be change NSFileProtectionType to Complete automatically and any running operation won't be able to access files after that.
+
+## How to Use Encryption Modes
+To use encryption modes in application, user need to call below function with the help of CDTDatastore object - 
+
+```objc
+# -(void)setEncryptionMode: (EncryptionModes)mode;'
+
+and you can call encryption function like this with the help of datastore object in OBJECTIVE C -
+
+# [datastore setEncryptionMode: mode1];
+You can replace mode1 with any other available mode.
+```
+
+
+```swift
+you can call encryption function like this with the help of datastore object in SWIFT -
+
+# dataStore.setEncryptionMode(.mode1)
+You can replace mode1 with any other available mode.
+```
+
+
 ### Conflicts
 
 An obvious repercussion of being able to replicate documents about the place

--- a/README.md
+++ b/README.md
@@ -287,9 +287,9 @@ migrating to a 0.16.0+ indexing and query version from a previous version
 see [Index and Querying Migration](https://github.com/cloudant/CDTDatastore/blob/master/doc/query-migration.md).
 
 
-### File Encryption Modes
+### File Protection Levels
 
-You can set a MODE from available options. Setting any mode will ensure the file protection that you want to apply on your files before starting and after finishing any operation on the files.
+You can set a File Protection Level from available options. Setting any mode will ensure the file protection that you want to apply on your files before starting and after finishing any operation on the files.
 There are 4 types of File protections available in iOS categorised by the key "NSFileProtectionType", and below are the different types of file protection -
 
 ### **NSFileProtectionComplete** -  The file is stored in an encrypted format on disk and cannot be read from or written to while the device is locked or booting.
@@ -303,7 +303,7 @@ There are 4 types of File protections available in iOS categorised by the key "N
 By Default value for **NSFileProtectionType** is **NSFileProtectionCompleteUntilFirstUserAuthentication**, that user can change at any point of time.
 
 
-In CDTDatastore framework, we have given 3 types of MODES that will help to set encryptions with some different behaviours. Below are the available modes -
+In CDTDatastore framework, we have given 3 types of OTFProtectionLevels that will help to set encryption with some different behaviours. Below are the available modes -
 
 ### **mode1** - User can use this mode in case Apps are guaranteed to complete syncing within 10 seconds, it will set NSFileProtectionType to CompleteUnlessOpen till 10 seconds finishes. After 10 seconds it will be change the NSFileProtectionType to Complete automatically and any running sycing  won't be able to access Files in background.
 
@@ -315,11 +315,11 @@ In CDTDatastore framework, we have given 3 types of MODES that will help to set 
 To use encryption modes in application, user need to call below function with the help of CDTDatastore object - 
 
 ```objc
-# -(void)setEncryptionMode: (EncryptionModes)mode;'
+# -(void)setProtectionLevel: (OTFProtectionLevel)level;'
 
 and you can call encryption function like this with the help of datastore object in OBJECTIVE C -
 
-# [datastore setEncryptionMode: mode1];
+# [datastore setProtectionLevel: mode1];
 You can replace mode1 with any other available mode.
 ```
 
@@ -327,7 +327,7 @@ You can replace mode1 with any other available mode.
 ```swift
 you can call encryption function like this with the help of datastore object in SWIFT -
 
-# dataStore.setEncryptionMode(.mode1)
+# dataStore.setProtectionLevel(.level)
 You can replace mode1 with any other available mode.
 ```
 


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Implemented the encryption of the local database in the iOS file system.

## Approach
See CDTDatastore.m - we're now observing the application lifecycle and using the appropriate encryption.

## Schema & API Changes
There is a new method called:
```
-(void)encryptFile: (NSFileProtectionType)type
```

The developers can use it to change the protection level.

## Security and Privacy
The local encryption has been enhanced so now the developers can change the file protection level.

## Testing
- No new tests because the current tests can't be compiled. The issues with current test target will have to be resolved first.

## Monitoring and Logging
- "No change"